### PR TITLE
UI change to show a footnote to indicate episode title truncation is supported

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -124,8 +124,8 @@ const absoluteTokens = [
 ];
 
 const episodeTitleTokens = [
-  { token: '{Episode Title}', example: 'Episode\'s Title' },
-  { token: '{Episode CleanTitle}', example: 'Episodes Title' }
+  { token: '{Episode Title}', example: 'Episode\'s Title', footNote: 1 },
+  { token: '{Episode CleanTitle}', example: 'Episodes Title', footNote: 1 }
 ];
 
 const qualityTokens = [
@@ -451,7 +451,7 @@ class NamingModal extends Component {
                   <FieldSet legend={translate('EpisodeTitle')}>
                     <div className={styles.groups}>
                       {
-                        episodeTitleTokens.map(({ token, example }) => {
+                        episodeTitleTokens.map(({ token, example, footNote }) => {
                           return (
                             <NamingOption
                               key={token}
@@ -459,6 +459,7 @@ class NamingModal extends Component {
                               value={value}
                               token={token}
                               example={example}
+                              footNote={footNote}
                               tokenSeparator={tokenSeparator}
                               tokenCase={tokenCase}
                               onPress={this.onOptionPress}
@@ -467,6 +468,11 @@ class NamingModal extends Component {
                         }
                         )
                       }
+                    </div>
+  
+                    <div className={styles.footNote}>
+                      <Icon className={styles.icon} name={icons.FOOTNOTE} />
+                      <InlineMarkdown data={translate('EpisodeTitleFootNote')} />
                     </div>
                   </FieldSet>
 

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -635,7 +635,7 @@
   "EpisodeRequested": "Episode Requested",
   "EpisodeSearchResultsLoadError": "Unable to load results for this episode search. Try again later",
   "EpisodeTitle": "Episode Title",
-  "EpisodeTitleFootNote": "Episode Title/CleanTitle support a `:<MAX_LENGTH>` suffix allowing you to truncate the episode title. Ellipsis (`...`) will be added when truncating. The length of the truncated text (including ellipsis) will be equal to the specificied max length. For example `{Episode Title:30}`.",
+  "EpisodeTitleFootNote": "Episode Title/CleanTitle support a `:MAX_LENGTH` suffix allowing you to truncate the episode title. Ellipsis (`...`) will be added when truncating. The length of the truncated text (including ellipsis) will be equal to the specificied max length. For example `{Episode Title:30}`.",
   "EpisodeTitleRequired": "Episode Title Required",
   "EpisodeTitleRequiredHelpText": "Prevent importing for up to 48 hours if the episode title is in the naming format and the episode title is TBA",
   "Episodes": "Episodes",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -635,6 +635,7 @@
   "EpisodeRequested": "Episode Requested",
   "EpisodeSearchResultsLoadError": "Unable to load results for this episode search. Try again later",
   "EpisodeTitle": "Episode Title",
+  "EpisodeTitleFootNote": "Episode Title/CleanTitle support a `:<MAX_LENGTH>` suffix allowing you to truncate the episode title. Ellipsis (`...`) will be added when truncating. The length of the truncated text (including ellipsis) will be equal to the specificied max length. For example `{Episode Title:30}`.",
   "EpisodeTitleRequired": "Episode Title Required",
   "EpisodeTitleRequiredHelpText": "Prevent importing for up to 48 hours if the episode title is in the naming format and the episode title is TBA",
   "Episodes": "Episodes",


### PR DESCRIPTION
#### Description

I noticed when looking through the code that episode title truncation is supported but not documented in the UI, so thought it would be helpful to add a footnote in the file naming dialog that indicated the support and how to use it.

#### Screenshots for UI Changes

<img width="807" alt="image" src="https://github.com/fireph/Sonarr/assets/443370/1148ce21-59b5-4854-8020-1ed97a5df248">

#### Database Migration
NO